### PR TITLE
Improve Audio Performance

### DIFF
--- a/js/audio.js
+++ b/js/audio.js
@@ -308,7 +308,7 @@ function outputAudio() {
 		35.7499681673944,35.74996031448245]
 	}
 	try {
-		const bufferLen = 5000
+		const bufferLen = 5000 // require 5000 to match knownGood
 		let context = new window.OfflineAudioContext(1, bufferLen, 44100)
 		dom.audioSupport = zE
 		try {

--- a/js/audio.js
+++ b/js/audio.js
@@ -308,7 +308,8 @@ function outputAudio() {
 		35.7499681673944,35.74996031448245]
 	}
 	try {
-		let context = new window.OfflineAudioContext(1, 44100, 44100)
+		const bufferLen = 5000
+		let context = new window.OfflineAudioContext(1, bufferLen, 44100)
 		dom.audioSupport = zE
 		try {
 			// oscillator
@@ -331,7 +332,7 @@ function outputAudio() {
 			context.startRendering()
 			context.oncomplete = function(event) {
 				try {
-					let copyTest = new Float32Array(44100)
+					let copyTest = new Float32Array(bufferLen)
 					event.renderedBuffer.copyFromChannel(copyTest, 0) // JSShelter errors here
 					let getTest = event.renderedBuffer.getChannelData(0) // JSShelter errors here
 					Promise.all([
@@ -342,7 +343,7 @@ function outputAudio() {
 						let sum = 0, sum2 = 0, sum3 = 0
 						for (let i=0; i < getTest.length; i++) {
 							let x = getTest[i]
-							if (i > 4499 && i < 5000) {sum += Math.abs(x)}
+							if (i > (bufferLen-501) && i < bufferLen) {sum += Math.abs(x)}
 							sum2 += x
 							sum3 += Math.abs(x)
 						}


### PR DESCRIPTION
This should improve audio performance by ~2x

- reduce buffer length from `44100` to `5000` 
  - this change affects the hashes, but not the sum
  - require buffer length of `5000` in order to match `knownGood` results
- use buffer length in the sum calculation to capture valid target range